### PR TITLE
Switch default openai chatbot model to gpt-4o.

### DIFF
--- a/client/app.py
+++ b/client/app.py
@@ -71,7 +71,7 @@ st.text("Select your OpenAI language model and embedding model.")
 
 if openai_chatbot_model := st.selectbox(
     "Chatbot Model",
-    ("gpt-4-turbo", "gpt-4", "gpt-3.5-turbo"),
+    ("gpt-4o", "gpt-4-turbo", "gpt-4", "gpt-3.5-turbo"),
     help="The model you select will be used to generate responses for your chatbot.",
 ):
     st.session_state["openai_chatbot_model"] = openai_chatbot_model

--- a/client/pages/chat.py
+++ b/client/pages/chat.py
@@ -43,7 +43,7 @@ else:
 
 # Set a default model
 if "openai_model" not in st.session_state:
-    st.session_state["openai_model"] = "gpt-4-turbo"
+    st.session_state["openai_model"] = "gpt-4o"
 
 # Initialize chat history
 if "messages" not in st.session_state:

--- a/client/settings.py
+++ b/client/settings.py
@@ -15,7 +15,7 @@ def load_session_state_from_db():
                 st.session_state[key] = settings[key]
 
     if "openai_chatbot_model" not in st.session_state:
-        st.session_state["openai_chatbot_model"] = "gpt-4-turbo"
+        st.session_state["openai_chatbot_model"] = "gpt-4o"
 
     if "openai_embedding_model" not in st.session_state:
         st.session_state["openai_embedding_model"] = "text-embedding-3-large"

--- a/dbt_llm_tools/chatbot.py
+++ b/dbt_llm_tools/chatbot.py
@@ -32,7 +32,7 @@ class Chatbot:
         database_path: str = ".local_storage/db.json",
         vector_db_path: str = ".local_storage/chroma.db",
         embedding_model: str = "text-embedding-3-large",
-        chatbot_model: str = "gpt-4-turbo",
+        chatbot_model: str = "gpt-4o",
     ) -> None:
         """
         Initializes a chatbot object along with a default set of instructions.
@@ -53,7 +53,7 @@ class Chatbot:
 
             chatbot_model (str, optional):
                 The name of the OpenAI chatbot model to be used.
-                Defaults to "gpt-4-turbo-preview".
+                Defaults to "gpt-4o".
 
         Returns:
             None

--- a/dbt_llm_tools/documentation_generator.py
+++ b/dbt_llm_tools/documentation_generator.py
@@ -27,7 +27,7 @@ class DocumentationGenerator:
         self,
         dbt_project_root: str,
         openai_api_key: str,
-        language_model: str = "gpt-4-turbo-preview",
+        language_model: str = "gpt-4o",
         database_path: str = "./directory.json",
     ) -> None:
         """
@@ -37,7 +37,7 @@ class DocumentationGenerator:
             dbt_project_root (str): Root of the dbt project
             openai_api_key (str): OpenAI API key
             language_model (str, optional): The language model to use for generating documentation.
-            Defaults to "gpt-4-turbo-preview".
+            Defaults to "gpt-4o".
             database_path (str, optional): Path to the directory file that stores the parsed dbt project.
             Defaults to "./directory.json".
 


### PR DESCRIPTION
I've switched gpt-4o in place of gpt-4-turbo for the chatbot model. By default, gpt-4o will be loaded now.

Also, I noticed that in chat.py file, `openai_model` is used in session_state instread of `openai_chatbot_model`:

```
# Set a default model
if "openai_model" not in st.session_state:
    st.session_state["openai_model"] = "gpt-4o"
```

I guess this is a mistake, if someone can confirm this then i'll go ahead and add a commit to fix that as well.